### PR TITLE
Inclusion of analytical partials in sellar_competences and ssbj test cases.

### DIFF
--- a/openlego/test_suite/test_examples/sellar_competences/kb/D1.py
+++ b/openlego/test_suite/test_examples/sellar_competences/kb/D1.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Copyright 2018 D. de Vries
+Copyright 2017 D. de Vries
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,11 +23,19 @@ from lxml import etree
 
 from openlego.api import AbstractDiscipline
 from openlego.utils.xml_utils import xml_safe_create_element
-from openlego.test_suite.test_examples.sellar_competences.kb import root_tag, x_x1, x_z1, x_z2, x_y2, x_y1
+from OpenLEGO_dev_scripts.test_cases.sellar_competences.kb import root_tag, x_x1, x_z1, x_z2, x_y2, x_y1
 from openlego.partials.partials import Partials
 
 
 class D1(AbstractDiscipline):
+
+    @property
+    def creator(self):
+        return u'D. de Vries'
+
+    @property
+    def description(self):
+        return u'First discipline of the Sellar problem'
 
     @property
     def supplies_partials(self):

--- a/openlego/test_suite/test_examples/sellar_competences/kb/D1.py
+++ b/openlego/test_suite/test_examples/sellar_competences/kb/D1.py
@@ -23,7 +23,7 @@ from lxml import etree
 
 from openlego.api import AbstractDiscipline
 from openlego.utils.xml_utils import xml_safe_create_element
-from OpenLEGO_dev_scripts.test_cases.sellar_competences.kb import root_tag, x_x1, x_z1, x_z2, x_y2, x_y1
+from openlego.test_suite.test_examples.sellar_competences.kb import root_tag, x_x1, x_z1, x_z2, x_y2, x_y1
 from openlego.partials.partials import Partials
 
 

--- a/openlego/test_suite/test_examples/sellar_competences/kb/D2.py
+++ b/openlego/test_suite/test_examples/sellar_competences/kb/D2.py
@@ -23,7 +23,7 @@ from lxml import etree
 
 from openlego.api import AbstractDiscipline
 from openlego.utils.xml_utils import xml_safe_create_element
-from OpenLEGO_dev_scripts.test_cases.sellar_competences.kb import root_tag, x_y1, x_y2, x_z1, x_z2
+from openlego.test_suite.test_examples.sellar_competences.kb import root_tag, x_y1, x_y2, x_z1, x_z2
 from openlego.partials.partials import Partials
 
 

--- a/openlego/test_suite/test_examples/sellar_competences/kb/D2.py
+++ b/openlego/test_suite/test_examples/sellar_competences/kb/D2.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Copyright 2018 D. de Vries
+Copyright 2017 D. de Vries
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,15 +20,22 @@ This file contains the definition of the Sellar D2 discipline.
 from __future__ import absolute_import, division, print_function
 
 from lxml import etree
-from numpy import sign
 
 from openlego.api import AbstractDiscipline
 from openlego.utils.xml_utils import xml_safe_create_element
-from openlego.test_suite.test_examples.sellar_competences.kb import root_tag, x_y1, x_y2, x_z1, x_z2
+from OpenLEGO_dev_scripts.test_cases.sellar_competences.kb import root_tag, x_y1, x_y2, x_z1, x_z2
 from openlego.partials.partials import Partials
 
 
 class D2(AbstractDiscipline):
+
+    @property
+    def creator(self):
+        return u'D. de Vries'
+
+    @property
+    def description(self):
+        return u'Second discipline of the Sellar problem'
 
     @property
     def supplies_partials(self):
@@ -76,10 +83,7 @@ class D2(AbstractDiscipline):
         doc = etree.parse(in_file)
         y1 = float(doc.xpath(x_y1)[0].text)
 
-        if not y1:
-            dy2_dy1 = sign(y1) * 1e99
-        else:
-            dy2_dy1 = y1 / (2. * abs(y1)**(3./2.))
+        dy2_dy1 = .5 * float(((y1 > 0) - (y1 < 0))) / abs(y1)**.5
 
         partials = Partials()
         partials.declare_partials(x_y2, [x_y1, x_z1, x_z2], [dy2_dy1, 1., 1.])

--- a/openlego/test_suite/test_examples/sellar_competences/kb/F.py
+++ b/openlego/test_suite/test_examples/sellar_competences/kb/F.py
@@ -25,7 +25,7 @@ from lxml import etree
 
 from openlego.api import AbstractDiscipline
 from openlego.utils.xml_utils import xml_safe_create_element
-from OpenLEGO_dev_scripts.test_cases.sellar_competences.kb import root_tag, x_x1, x_y1, x_y2, x_z2, x_f1
+from openlego.test_suite.test_examples.sellar_competences.kb import root_tag, x_x1, x_y1, x_y2, x_z2, x_f1
 from openlego.partials.partials import Partials
 
 

--- a/openlego/test_suite/test_examples/sellar_competences/kb/F.py
+++ b/openlego/test_suite/test_examples/sellar_competences/kb/F.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Copyright 2018 D. de Vries
+Copyright 2017 D. de Vries
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,11 +25,19 @@ from lxml import etree
 
 from openlego.api import AbstractDiscipline
 from openlego.utils.xml_utils import xml_safe_create_element
-from openlego.test_suite.test_examples.sellar_competences.kb import root_tag, x_x1, x_y1, x_y2, x_z2, x_f1
+from OpenLEGO_dev_scripts.test_cases.sellar_competences.kb import root_tag, x_x1, x_y1, x_y2, x_z2, x_f1
 from openlego.partials.partials import Partials
 
 
 class F(AbstractDiscipline):
+
+    @property
+    def creator(self):
+        return u'D. de Vries'
+
+    @property
+    def description(self):
+        return u'Objective function of the Sellar problem'
 
     @property
     def supplies_partials(self):

--- a/openlego/test_suite/test_examples/sellar_competences/kb/G1.py
+++ b/openlego/test_suite/test_examples/sellar_competences/kb/G1.py
@@ -23,7 +23,7 @@ from lxml import etree
 
 from openlego.api import AbstractDiscipline
 from openlego.utils.xml_utils import xml_safe_create_element
-from OpenLEGO_dev_scripts.test_cases.sellar_competences.kb import root_tag, x_y1, x_g1
+from openlego.test_suite.test_examples.sellar_competences.kb import root_tag, x_y1, x_g1
 from openlego.partials.partials import Partials
 
 

--- a/openlego/test_suite/test_examples/sellar_competences/kb/G1.py
+++ b/openlego/test_suite/test_examples/sellar_competences/kb/G1.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Copyright 2018 D. de Vries
+Copyright 2017 D. de Vries
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,11 +23,19 @@ from lxml import etree
 
 from openlego.api import AbstractDiscipline
 from openlego.utils.xml_utils import xml_safe_create_element
-from openlego.test_suite.test_examples.sellar_competences.kb import root_tag, x_y1, x_g1
+from OpenLEGO_dev_scripts.test_cases.sellar_competences.kb import root_tag, x_y1, x_g1
 from openlego.partials.partials import Partials
 
 
 class G1(AbstractDiscipline):
+
+    @property
+    def creator(self):
+        return u'D. de Vries'
+
+    @property
+    def description(self):
+        return u'First constraint function of the Sellar problem'
 
     @property
     def supplies_partials(self):

--- a/openlego/test_suite/test_examples/sellar_competences/kb/G2.py
+++ b/openlego/test_suite/test_examples/sellar_competences/kb/G2.py
@@ -23,7 +23,7 @@ from lxml import etree
 
 from openlego.api import AbstractDiscipline
 from openlego.utils.xml_utils import xml_safe_create_element
-from OpenLEGO_dev_scripts.test_cases.sellar_competences.kb import root_tag, x_y2, x_g2
+from openlego.test_suite.test_examples.sellar_competences.kb import root_tag, x_y2, x_g2
 from openlego.partials.partials import Partials
 
 

--- a/openlego/test_suite/test_examples/sellar_competences/kb/G2.py
+++ b/openlego/test_suite/test_examples/sellar_competences/kb/G2.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Copyright 2018 D. de Vries
+Copyright 2017 D. de Vries
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,15 +23,23 @@ from lxml import etree
 
 from openlego.api import AbstractDiscipline
 from openlego.utils.xml_utils import xml_safe_create_element
-from openlego.test_suite.test_examples.sellar_competences.kb import root_tag, x_y2, x_g2
+from OpenLEGO_dev_scripts.test_cases.sellar_competences.kb import root_tag, x_y2, x_g2
 from openlego.partials.partials import Partials
 
 
 class G2(AbstractDiscipline):
 
     @property
+    def creator(self):
+        return u'D. de Vries'
+
+    @property
+    def description(self):
+        return u'First constraint function of the Sellar problem'
+
+    @property
     def supplies_partials(self):
-        return False
+        return True
 
     def generate_input_xml(self):
         root = etree.Element(root_tag)

--- a/openlego/test_suite/test_examples/ssbj/kb/__init__.py
+++ b/openlego/test_suite/test_examples/ssbj/kb/__init__.py
@@ -50,7 +50,7 @@ def deploy():
 
 def clean():
     for discipline in list_disciplines:
-        for pf in ['-input.xml', '-output.xml']:
+        for pf in ['-input.xml', '-output.xml', '-partials.xml']:
             os.remove(os.path.join(dir_path, discipline + pf))
     os.remove(os.path.join(dir_path, 'SSBJ-base.xml'))
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         'openmdao>=2.4.0',
         'lxml',
         'numpy',
-        'ssbjkadmos',
+        'ssbjkadmos>=0.1.3',
         'cached-property'
     ],
     include_package_data=True,


### PR DESCRIPTION
I have just finished the implementation of analytic partials for both the sellar_competences test case as well as the ssbj case. Note that for the ssbj test case the ssbjkadmos package needs to be updated to version 0.1.3. This version has just been released and the installation requirements of openlego have been adjusted accordingly.

All tests have been rerun successfully.