### PR TITLE
Added sleeping_time for mathematical functions and workarounds for mpirun

### DIFF
--- a/openlego/core/exec_comp.py
+++ b/openlego/core/exec_comp.py
@@ -23,7 +23,6 @@ class ExecComp(OpenmdaoExecComp):
         outputs : `Vector`
             `Vector` containing outputs.
         """
-        for expr in self._codes:
-            exec(expr, _expr_dict, _IODict(outputs, inputs))
+        OpenmdaoExecComp.compute(self, inputs, outputs)
         if self.sleep_time is not None:
             time.sleep(self.sleep_time)

--- a/openlego/core/exec_comp.py
+++ b/openlego/core/exec_comp.py
@@ -1,5 +1,4 @@
 from openmdao.api import ExecComp as OpenmdaoExecComp
-from openmdao.components.exec_comp import _expr_dict, _IODict
 import time
 
 

--- a/openlego/core/exec_comp.py
+++ b/openlego/core/exec_comp.py
@@ -1,0 +1,29 @@
+from openmdao.api import ExecComp as OpenmdaoExecComp
+from openmdao.components.exec_comp import _expr_dict, _IODict
+import time
+
+
+class ExecComp(OpenmdaoExecComp):
+    """Executable component based on mathematical expression with the additional function of adding a sleep time to
+    simulate longer execution times."""
+
+    def __init__(self, exprs, sleep_time=None, **kwargs):
+        super(ExecComp, self).__init__(exprs, **kwargs)
+        self.sleep_time = sleep_time
+
+    def compute(self, inputs, outputs):
+        """
+        Execute this component's assignment statements.
+
+        Parameters
+        ----------
+        inputs : `Vector`
+            `Vector` containing inputs.
+
+        outputs : `Vector`
+            `Vector` containing outputs.
+        """
+        for expr in self._codes:
+            exec(expr, _expr_dict, _IODict(outputs, inputs))
+        if self.sleep_time is not None:
+            time.sleep(self.sleep_time)

--- a/openlego/core/model.py
+++ b/openlego/core/model.py
@@ -30,7 +30,7 @@ from cached_property import cached_property
 from lxml import etree
 from lxml.etree import _Element, _ElementTree
 from openmdao.api import Group, IndepVarComp, LinearBlockGS, NonlinearBlockGS, LinearBlockJac, NonlinearBlockJac, \
-    LinearRunOnce, ExecComp, NonlinearRunOnce, DirectSolver
+    LinearRunOnce, NonlinearRunOnce, DirectSolver
 from typing import Union, Optional, List, Any, Dict, Tuple
 
 from openlego.utils.general_utils import parse_cmdows_value, str_to_valid_sys_name, parse_string
@@ -39,6 +39,7 @@ from openlego.utils.cmdows_utils import get_element_by_uid, get_related_paramete
 from .abstract_discipline import AbstractDiscipline
 from .cmdows import CMDOWSObject, InvalidCMDOWSFileError
 from .discipline_component import DisciplineComponent
+from .exec_comp import ExecComp
 
 
 class LEGOModel(CMDOWSObject, Group):
@@ -293,8 +294,12 @@ class LEGOModel(CMDOWSObject, Group):
 
                                     if eq_label in eq_expr:
                                         promotes.append((eq_label, input_name))
+                                if isinstance(mathematical_function.find('sleepTime'), _Element):
+                                    sleep_time = float(mathematical_function.findtext('sleepTime'))
+                                else:
+                                    sleep_time = None
                                 group.add_subsystem(str_to_valid_sys_name(eq_uid),
-                                                    ExecComp(eq_output_label + ' = ' + eq_expr),
+                                                    ExecComp(eq_output_label + ' = ' + eq_expr, sleep_time=sleep_time),
                                                     promotes=promotes + [(eq_output_label, eq_output), ])
                 _mathematical_functions.update({uid: group})
 

--- a/openlego/core/model.py
+++ b/openlego/core/model.py
@@ -548,9 +548,9 @@ class LEGOModel(CMDOWSObject, Group):
                     name = xpath_to_param(value)
                     if name not in _model_super_inputs:
                         # Determine the targets of this input
-                        targets = [x for x in self.elem_cmdows.xpath(r'workflow/dataGraph/edges/edge[fromParameterUID'
-                                                                     r'="{}"]/toExecutableBlockUID/text()'
-                                                                     .format(value)) if x in self.model_exec_blocks]
+                        targets = [x for x in self.model_exec_blocks if value in self.elem_cmdows.xpath(
+                                   r'workflow/dataGraph/edges/edge[toExecutableBlockUID="{}"]/fromParameterUID/'
+                                   r'text()'.format(x))]
                         _model_super_inputs.update({name: {'val': self.variable_sizes[name], 'targets': targets}})
         return _model_super_inputs
 

--- a/openlego/core/model.py
+++ b/openlego/core/model.py
@@ -273,6 +273,10 @@ class LEGOModel(CMDOWSObject, Group):
                                 raise AssertionError('Could not find equation UID.')
                         else:
                             eqs_elem = output.find('equations')
+                        if isinstance(mathematical_function.find('sleepTime'), _Element):
+                            sleep_time = float(mathematical_function.findtext('sleepTime'))
+                        else:
+                            sleep_time = None
                         for equation in eqs_elem.iter('equation'):
                             if equation.attrib['language'] == 'Python':
                                 eq_uid = equation.getparent().attrib['uID']
@@ -294,13 +298,12 @@ class LEGOModel(CMDOWSObject, Group):
 
                                     if eq_label in eq_expr:
                                         promotes.append((eq_label, input_name))
-                                if isinstance(mathematical_function.find('sleepTime'), _Element):
-                                    sleep_time = float(mathematical_function.findtext('sleepTime'))
-                                else:
-                                    sleep_time = None
                                 group.add_subsystem(str_to_valid_sys_name(eq_uid),
                                                     ExecComp(eq_output_label + ' = ' + eq_expr, sleep_time=sleep_time),
                                                     promotes=promotes + [(eq_output_label, eq_output), ])
+                                # sleep_time is set to None to only have simulated time for one equation of the
+                                # mathematical function in the CMDOWS file
+                                sleep_time=None
                 _mathematical_functions.update({uid: group})
 
         return _mathematical_functions

--- a/openlego/core/model.py
+++ b/openlego/core/model.py
@@ -262,6 +262,12 @@ class LEGOModel(CMDOWSObject, Group):
                     if '/architectureNodes/final' not in output_name:
                         required_outputs.append(output_name)
 
+                # Get the sleeping time for the mathematical function
+                if isinstance(mathematical_function.find('sleepTime'), _Element):
+                    sleep_time = float(mathematical_function.findtext('sleepTime'))
+                else:
+                    sleep_time = None
+
                 # Then create mathematical subsystems for each output
                 for output in mathematical_function.iter('output'):
                     if output.find('parameterUID').text in required_outputs:
@@ -273,10 +279,6 @@ class LEGOModel(CMDOWSObject, Group):
                                 raise AssertionError('Could not find equation UID.')
                         else:
                             eqs_elem = output.find('equations')
-                        if isinstance(mathematical_function.find('sleepTime'), _Element):
-                            sleep_time = float(mathematical_function.findtext('sleepTime'))
-                        else:
-                            sleep_time = None
                         for equation in eqs_elem.iter('equation'):
                             if equation.attrib['language'] == 'Python':
                                 eq_uid = equation.getparent().attrib['uID']

--- a/openlego/core/problem.py
+++ b/openlego/core/problem.py
@@ -365,7 +365,7 @@ class LEGOProblem(CMDOWSObject, Problem):
         for name, value in iteritems(self._initial_condition_cache):
             try:
                 self[name] = value
-            except:
+            except KeyError:
                 pass
 
         # Clean up cache

--- a/openlego/test_suite/test_examples/sellar_competences/sellar_competences_test.py
+++ b/openlego/test_suite/test_examples/sellar_competences/sellar_competences_test.py
@@ -26,7 +26,7 @@ import unittest
 from openlego.core.problem import LEGOProblem
 import openlego.test_suite.test_examples.sellar_competences.kb as kb
 
-from openlego.utils.general_utils import clean_dir_filtered
+from openlego.utils.general_utils import clean_dir_filtered, pyoptsparse_installed
 
 # Settings for logging
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
@@ -189,7 +189,11 @@ class TestSellarCompetences(unittest.TestCase):
 
     def test_co(self):
         """Solve the Sellar problem using the Collaborative Optimization architecture."""
-        self.assertion_mdo(*run_openlego(9))
+        if pyoptsparse_installed():
+            self.assertion_mdo(*run_openlego(9))
+        else:
+            print('Skipped test due to missing PyOptSparse installation.')
+            pass
 
     def __del__(self):
         kb.clean()

--- a/openlego/test_suite/test_examples/sellar_math/cmdows_files/Mdao_MDF-GS.xml
+++ b/openlego/test_suite/test_examples/sellar_math/cmdows_files/Mdao_MDF-GS.xml
@@ -50,6 +50,7 @@
       <mathematicalFunction uID="F1">
         <label>F1</label>
         <functionType>regular</functionType>
+        <sleepTime>0.1</sleepTime>
         <inputs>
           <input>
             <parameterUID>/dataSchema/geometry/x1</parameterUID>

--- a/openlego/test_suite/test_examples/sellar_math/sellar_math_test.py
+++ b/openlego/test_suite/test_examples/sellar_math/sellar_math_test.py
@@ -25,7 +25,7 @@ import unittest
 
 from openlego.core.problem import LEGOProblem
 
-from openlego.utils.general_utils import clean_dir_filtered
+from openlego.utils.general_utils import clean_dir_filtered, pyoptsparse_installed
 
 # Settings for logging
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
@@ -182,7 +182,11 @@ class TestSellarMath(unittest.TestCase):
 
     def test_co(self):
         """Solve the Sellar problem using the Collaborative Optimization architecture."""
-        self.assertion_mdo(*run_openlego(9))
+        if pyoptsparse_installed():
+            self.assertion_mdo(*run_openlego(9))
+        else:
+            print('Skipped test due to missing PyOptSparse installation.')
+            pass
 
     def __del__(self):
         clean_dir_filtered(os.path.dirname(__file__), ['case_reader_', 'n2_Mdao_', 'sellar-output.xml', 'SLSQP.out'])

--- a/openlego/test_suite/test_examples/ssbj/ssbj_test.py
+++ b/openlego/test_suite/test_examples/ssbj/ssbj_test.py
@@ -25,7 +25,7 @@ import unittest
 
 from openlego.core.problem import LEGOProblem
 import openlego.test_suite.test_examples.ssbj.kb as kb
-from openlego.utils.general_utils import clean_dir_filtered
+from openlego.utils.general_utils import clean_dir_filtered, pyoptsparse_installed
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
 
@@ -271,7 +271,11 @@ class TestSsbj(unittest.TestCase):
 
     def test_co(self):
         """Test run the SSBJ problem using the CO architecture."""
-        self.assertion_co(*run_openlego(13))
+        if pyoptsparse_installed():
+            self.assertion_co(*run_openlego(13))
+        else:
+            print('Skipped test due to missing PyOptSparse installation.')
+            pass
 
     def __del__(self):
         kb.clean()

--- a/openlego/utils/general_utils.py
+++ b/openlego/utils/general_utils.py
@@ -26,6 +26,7 @@ from os import path
 
 import numpy as np
 from lxml import etree
+
 from openmdao.core.driver import Driver
 from typing import Callable, Any, Optional, Union, Type, List, SupportsInt, SupportsFloat
 
@@ -347,3 +348,23 @@ def clean_dir_filtered(dr, filters):
             if fltr in f:
                 os.remove(f)
                 continue
+
+
+class PyOptSparseImportError(ImportError):
+
+    def __init__(self):
+        msg = "Cannot import name pyOptSparseDriver. This probably means that this package has not been installed to " \
+              "your Python packages. Note that it needs to be installed to your Python manually (no PyPIdistribution " \
+              "available). pyOptSparse can be downloaded here: https://github.com/mdolab/pyoptsparse"
+        super(PyOptSparseImportError, self).__init__(msg)
+
+
+def pyoptsparse_installed():
+    # type: () -> bool
+    """Check for the installation of the PyOptSparse Python package."""
+    try:
+        from openmdao.api import pyOptSparseDriver
+    except ImportError:
+        print(PyOptSparseImportError().message)
+        return False
+    return True

--- a/setup.py
+++ b/setup.py
@@ -52,10 +52,10 @@ setup(
     packages=find_packages(),
     package_data={'openlego.partials': ['partials.xsd']},
     install_requires=[
-        'openmdao>=2.4.0',
+        'openmdao>=2.5.0',
         'lxml',
         'numpy',
-        'ssbjkadmos>=0.1.3',
+        'ssbjkadmos>=0.1.6',
         'cached-property'
     ],
     include_package_data=True,


### PR DESCRIPTION
Sleeping time has been added to ExecComp to allow the simulation of execution times for testing purposes.
In additions, some small workaround have been included to support parallel processing with mpi4py.